### PR TITLE
moved include inside class

### DIFF
--- a/lib/gherkin_lint/issue.rb
+++ b/lib/gherkin_lint/issue.rb
@@ -1,9 +1,9 @@
 require 'term/ansicolor'
-include Term::ANSIColor
 
 module GherkinLint
   # entity value class for issues
   class Issue
+    include Term::ANSIColor
     attr_reader :name, :references, :description
 
     def initialize(name, references, description = nil)


### PR DESCRIPTION
Moved the include inside so that it does not affect anything outside of the scope of the project.  Currently it was including the methods onto the Object class.