### PR TITLE
Fix Windows Rake task issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+
+gemspec
+
 gem 'amatch'
 gem 'aruba', '1.0.0.pre.alpha.2'
 gem 'engtagger', '>=0.2.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require 'rake/testtask'
 
-ENV['RUBYLIB'] ||= "lib:#{ENV['RUBYLIB']}"
-
 task default: :build
 
 desc 'Builds the Gem.'
@@ -46,5 +44,5 @@ task :self_check do
     UnknownVariable
     BadScenarioName
   ]
-  sh "./bin/gherkin_lint --disable #{disabled_checks.join ','} features/*.feature"
+  sh "ruby ./bin/gherkin_lint --disable #{disabled_checks.join ','} features/*.feature"
 end


### PR DESCRIPTION
Explicitly calling `ruby` in a shell command because Windows does not
magically interpret comment lines as directives. Also, removing load
path manipulation because it would have to be manipulated different
ways for different operating systems and Bundler can handle it for us
automatically.