### PR TITLE
Gemspec cleanup

### DIFF
--- a/gherkin_lint.gemspec
+++ b/gherkin_lint.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.files       = `git ls-files`.split("\n")
   s.executables = s.files.grep(%r{^bin/}) { |file| File.basename(file) }
-  s.add_runtime_dependency 'gherkin', ['>= 4.0.0']
-  s.add_runtime_dependency 'term-ansicolor', ['>= 1.3.2']
-  s.add_runtime_dependency 'amatch', ['>= 0.3.0']
-  s.add_runtime_dependency 'engtagger', ['>=0.2.0']
-  s.add_runtime_dependency 'multi_json', ['>=1.12.1']
-  s.add_development_dependency 'aruba', ['>= 0.6.2']
+  s.add_runtime_dependency 'gherkin', ['>= 4.0.0', '< 6.0']
+  s.add_runtime_dependency 'term-ansicolor', ['~> 1.3', '>= 1.3.2']
+  s.add_runtime_dependency 'amatch', ['~> 0.3', '>= 0.3.0']
+  s.add_runtime_dependency 'engtagger', ['~> 0.2', '>= 0.2.0']
+  s.add_runtime_dependency 'multi_json', ['~> 1.12', '>= 1.12.1']
+  s.add_development_dependency 'aruba', ['~> 0.6', '>= 0.6.2']
 end

--- a/gherkin_lint.gemspec
+++ b/gherkin_lint.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.files       = `git ls-files`.split("\n")
   s.executables = s.files.grep(%r{^bin/}) { |file| File.basename(file) }
-  s.add_runtime_dependency 'gherkin', ['>= 4.0.0', '< 6.0']
-  s.add_runtime_dependency 'term-ansicolor', ['~> 1.3', '>= 1.3.2']
   s.add_runtime_dependency 'amatch', ['~> 0.3', '>= 0.3.0']
   s.add_runtime_dependency 'engtagger', ['~> 0.2', '>= 0.2.0']
+  s.add_runtime_dependency 'gherkin', ['>= 4.0.0', '< 6.0']
   s.add_runtime_dependency 'multi_json', ['~> 1.12', '>= 1.12.1']
+  s.add_runtime_dependency 'term-ansicolor', ['~> 1.3', '>= 1.3.2']
   s.add_development_dependency 'aruba', ['~> 0.6', '>= 0.6.2']
 end

--- a/gherkin_lint.gemspec
+++ b/gherkin_lint.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.description = 'Lint Gherkin Files'
   s.authors     = ['Stefan Rohe', 'Nishtha Argawal', 'John Gluck']
   s.homepage    = 'http://github.com/funkwerk/gherkin_lint/'
+  s.license     = 'MIT'
   s.files       = `git ls-files`.split("\n")
   s.executables = s.files.grep(%r{^bin/}) { |file| File.basename(file) }
   s.add_runtime_dependency 'gherkin', ['>= 4.0.0']


### PR DESCRIPTION
I took care of most of the build warnings and RuboCop violations in the `.gemspec`. There is still a warning about not having a contact email, but that's up to you.